### PR TITLE
Harden release CI: require released commit on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     # .tool-versions and a full mix deps.get (not --only test).
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history so the "on main" ancestry check below works
       - uses: erlef/setup-beam@v1
         with:
           version-file: .tool-versions
@@ -26,6 +28,15 @@ jobs:
             echo "::error::Release tag ($TAG) does not match mix.exs @version ($VSN); aborting publish."
             exit 1
           fi
+
+      - name: Verify the released commit is on main
+        run: |
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Released commit $GITHUB_SHA is not on origin/main; refusing to publish an off-mainline release."
+            exit 1
+          fi
+          echo "Released commit $GITHUB_SHA is on origin/main."
 
       - run: mix deps.get
 

--- a/docs/superpowers/specs/2026-06-02-hex-release-ci-design.md
+++ b/docs/superpowers/specs/2026-06-02-hex-release-ci-design.md
@@ -17,22 +17,26 @@ release, rather than from a maintainer's machine.
 | ----------- | ------------------------------------------------------------------------------------------- |
 | Trigger     | GitHub **Release published** (`on: release: types: [published]`)                            |
 | Scope       | Package **and** docs (`mix hex.publish --yes`)                                              |
-| Safety gate | Verify the release tag (minus leading `v`) equals `mix.exs` `@version`; fail on mismatch    |
+| Safety gate | Two gates, both fail-hard: (1) release tag (minus leading `v`) equals `mix.exs` `@version`; (2) the released commit is an ancestor of `origin/main` (no off-mainline publish) |
 | Auth        | `HEX_API_KEY` repo secret, passed as env to the publish step                                |
-| Toolchain   | Elixir 1.19 / OTP 28 (where ex_doc 0.40 builds; docs publishing needs dev-only ex_doc)      |
+| Toolchain   | From `.tool-versions` (`version-file` + `version-type: strict`); docs publishing needs dev-only ex_doc |
 | Deps        | Full `mix deps.get` (dev deps incl. ex_doc) — NOT `--only test`, because docs are published |
 | Existing CI | `ci.yml` unchanged; this is a separate release-only workflow                                |
 
 ## Component
 
-New file `.github/workflows/release.yml`, one `publish` job:
+`.github/workflows/release.yml`, one `publish` job:
 
-1. `actions/checkout@v4` (checks out the released tag's commit).
-2. `erlef/setup-beam@v1` with Elixir 1.19 / OTP 28.
-3. **Safety gate** — parse `@version` from `mix.exs` via grep (no compile needed), strip the
-   leading `v` from `GITHUB_REF_NAME`, fail with `::error::` if they differ.
-4. `mix deps.get`.
-5. `mix hex.publish --yes` with `env: HEX_API_KEY: ${{ secrets.HEX_API_KEY }}`.
+1. `actions/checkout@v6` with `fetch-depth: 0` (full history for the ancestry check).
+2. `erlef/setup-beam@v1` with `version-file: .tool-versions`, `version-type: strict`.
+3. **Safety gate 1 (tag == version)** — parse `@version` from `mix.exs` via grep (no compile
+   needed), strip the leading `v` from `GITHUB_REF_NAME`, fail with `::error::` if they differ.
+4. **Safety gate 2 (on main)** — `git fetch --no-tags origin main`, then
+   `git merge-base --is-ancestor "$GITHUB_SHA" origin/main`; fail if the released commit is not
+   on `main`. This makes the workflow itself reject an off-mainline release (e.g. a tag on a
+   docs-only commit), rather than relying on the maintainer's manual SHA check.
+5. `mix deps.get`.
+6. `mix hex.publish --yes` with `env: HEX_API_KEY: ${{ secrets.HEX_API_KEY }}`.
 
 ## One-time maintainer setup (outside this repo)
 
@@ -62,4 +66,5 @@ mix hex.user key generate --key-name defconst-ci --permission api:write
 - Publishing a GitHub Release whose tag matches `mix.exs` `@version` publishes the package +
   docs to Hex via CI, with no local `mix hex.publish` needed.
 - A release whose tag does not match `@version` fails the workflow before publishing.
+- A release on a commit not on `origin/main` fails the workflow before publishing.
 - `actionlint` is clean; the version-gate logic is unit-tested locally.


### PR DESCRIPTION
## Medium (release-safety)
`release.yml` previously only checked the release tag (minus `v`) against `mix.exs` `@version`, then ran `mix hex.publish --yes`. A GitHub Release on any off-mainline commit that still read the target `@version` would pass and publish. The plan had a manual SHA guard, but the workflow is the irreversible boundary, so the check belongs there.

This adds a second fail-hard gate in the workflow:
- `actions/checkout` now uses `fetch-depth: 0` (full history).
- New step: `git fetch --no-tags origin main` then `git merge-base --is-ancestor "$GITHUB_SHA" origin/main` — aborts the publish if the released commit is not on `main`.

Verified locally: a commit on `main` passes; an off-mainline commit (the squash-merged `revive-and-modernize` tip) aborts.

## Low (doc drift)
Synced `2026-06-02-hex-release-ci-design.md` to the actual workflow: `actions/checkout@v6`, toolchain from `.tool-versions` (strict), and the new on-main gate.

actionlint clean.